### PR TITLE
Make the distributed training slurm friendly

### DIFF
--- a/distributed_train.sh
+++ b/distributed_train.sh
@@ -2,114 +2,74 @@
 #
 #SBATCH --job-name=roberta
 #SBATCH --output=dist_stdout.txt
-#SBATCH --mail-type=ALL         # Mail events (NONE, BEGIN, END, FAIL, ALL)
-#SBATCH --mail-user=jmorton@flatironinstitute.org
+#Add SBATCH back if you'd like to be emailed/notified
+# --mail-type=ALL         # Mail events (NONE, BEGIN, END, FAIL, ALL)
+# --mail-user=jmorton@flatironinstitute.org
 #
-#SBATCH --ntasks=4
-#SBATCH --cpus-per-task 40
+#--ntasks=4
+#--cpus-per-task 40
 #SBATCH --time=100:00:00
 #SBATCH -N 2
 #SBATCH -p gpu
-#SBATCH --gres=gpu:4
+#SBATCH --gres=gpu:v100-32gb:4
+#SBATCH -c 25
 #SBATCH --exclusive
 
 # see https://www.glue.umd.edu/hpcc/help/software/pytorch.html#distrib
-
-# ip=`curl ifconfig.me`
+# Replace with your own virtualenv controls.
+source /mnt/home/cchandler/.bashrc
+conda activate shaggy
 
 module load cuda/10.1.105_418.39
 module load cudnn/v7.6.2-cuda-10.1
 module load nccl/2.4.2-cuda-10.1
-#export NCCL_DEBUG=INFO
-#export NCCL_DEBUG_SUBSYS=ALL
 
-# TODO: Change environment if necessary
-source ~/venvs/roberta/bin/activate
+export TOTAL_UPDATES=100000    # Total number of training steps
+export WARMUP_UPDATES=10000    # Warmup the learning rate over this many updates
+export PEAK_LR=0.0006          # Peak learning rate, adjust as needed
+export TOKENS_PER_SAMPLE=1024  # Max sequence length
+export MAX_POSITIONS=1024      # Num. positional embeddings (usually same as above)
+export MAX_SENTENCES=1         # Number of sequences per batch (batch size)
+export UPDATE_FREQ=8           # Increase the batch size 8x
+export DATA_DIR=/mnt/home/mgt/data/uniref50
+export SAVE_DIR=/mnt/home/cchandler/ceph/shaggy/save
+export TB_DIR=/mnt/home/cchandler/ceph/shaggy/tb
 
-TOTAL_UPDATES=100000    # Total number of training steps
-WARMUP_UPDATES=10000    # Warmup the learning rate over this many updates
-PEAK_LR=0.0006          # Peak learning rate, adjust as needed
-TOKENS_PER_SAMPLE=1024  # Max sequence length
-MAX_POSITIONS=1024      # Num. positional embeddings (usually same as above)
-MAX_SENTENCES=1         # Number of sequences per batch (batch size)
-UPDATE_FREQ=8           # Increase the batch size 8x
-DATA_DIR=/mnt/home/mgt/data/uniref50
-SAVE_DIR=/mnt/home/jmorton/research/gert/roberta-checkpoints/uniref50-test
-TB_DIR=/mnt/home/jmorton/research/gert/roberta-checkpoints/tensorboard
-
-OMP_NUM_THREADS=10
-echo `which python`
-
-NPROC_PER_NODE=10
-COMMAND="$(which fairseq-train) $DATA_DIR \
-    --task masked_lm --criterion masked_lm \
-    --arch roberta_base --sample-break-mode complete --tokens-per-sample $TOKENS_PER_SAMPLE \
-    --optimizer adam --adam-betas '(0.9,0.98)' --adam-eps 1e-6 --clip-norm 0.0 \
-    --lr-scheduler polynomial_decay --lr $PEAK_LR --warmup-updates $WARMUP_UPDATES --total-num-update $TOTAL_UPDATES \
-    --dropout 0.1 --attention-dropout 0.1 --weight-decay 0.01 \
-    --max-sentences $MAX_SENTENCES --update-freq $UPDATE_FREQ \
-    --max-update $TOTAL_UPDATES --log-format tqdm --log-interval 1 \
-    --ddp-backend=no_c10d \
-    --fix-batches-to-gpus \
-    --bpe gpt2 --memory-efficient-fp16 \
-    --save-interval-updates 10 \
-    --keep-interval-updates 3 \
-    --save-dir $SAVE_DIR"
-
-MASTER=`/bin/hostname -s`
-SLAVES=`scontrol show hostnames $SLURM_JOB_NODELIST | grep -v $MASTER`
+WORKERS=`scontrol show hostnames $SLURM_JOB_NODELIST`
 # I got pytorch distributed notes from
 # 1. http://hpcc.umd.edu/hpcc/help/software/pytorch.html
 # 2. http://aaronsplace.co.uk/blog/2018-12-08-pytorch-distributed-learning.html
 
-
 #Make sure this node (MASTER) comes first
-HOSTLIST="$MASTER $SLAVES"
-
-#Get a random unused port on this host(MASTER) between 2000 and 9999
-#First line gets list of unused ports
-#2nd line restricts between 2000 and 9999
-#3rd line gets single random port from the list
-#MPORT=`ss -tan | awk '{print $4}' | cut -d':' -f2 | \
-#grep "[2-9][0-9]\{3,3\}" | grep -v "[0-9]\{5,5\}" | \
-#sort | uniq | shuf`
+HOSTLIST="$WORKERS"
 
 #https://unix.stackexchange.com/a/132524
-MPORT=`python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'`
+#It's just easier to use a fixed port in our environment
+export MPORT=4664
 
-echo $COMMAND
-echo $MPORT
-echo $MASTER
-echo $SLURM_JOB_NUM_NODES
-#Launch the pytorch processes, first on master (first in $HOSTLIST) then
-#on the slaves
+#Nproc per node needs to match the GPU count
+export NPROC_PER_NODE=4
+export WORLDSIZE=$(( NPROC_PER_NODE * SLURM_JOB_NUM_NODES ))
+
+export NCCL_DEBUG_SUBSYS=ALL
+export NCCL_DEBUG=WARN
+
+echo "Current world size $WORLDSIZE"
+echo "Current number of nodes $SLURM_JOB_NUM_NODES"
+echo "Current hostlist $HOSTLIST"
+
+# Write the nodelist with expected ranks
+echo $HOSTLIST | python /mnt/home/cchandler/Development/shaggy-dog/node_to_rank_writer.py $SAVE_DIR/ranklist
+
 RANK=0
-#port=`echo $MPORT | awk '{print $'$((RANK+1))'}'`
-#port=4000
-#echo $port
-NPROC_PER_NODE=2
-SLURM_JOB_NUM_NODES=4
+# This loop isn't really needed, but it made it easier to pull out the 'master' node
 for node in $HOSTLIST
 do
-    #ssh -q $node \
-    srun python -m torch.distributed.launch \
-    --nproc_per_node=$NPROC_PER_NODE --nnodes=$SLURM_JOB_NUM_NODES \
-    --node_rank=$RANK --master_addr="$MASTER" --master_port="$MPORT" \
-    $(which fairseq-train) $DATA_DIR \
-    --task masked_lm --criterion masked_lm \
-    --sample-break-mode complete --tokens-per-sample $TOKENS_PER_SAMPLE \
-    --optimizer adam --adam-betas '(0.9,0.98)' --adam-eps 1e-6 --clip-norm 0.0 \
-    --lr-scheduler polynomial_decay --lr $PEAK_LR --warmup-updates $WARMUP_UPDATES --total-num-update $TOTAL_UPDATES \
-    --dropout 0.1 --attention-dropout 0.1 --weight-decay 0.01 \
-    --max-sentences $MAX_SENTENCES --update-freq $UPDATE_FREQ \
-    --max-update $TOTAL_UPDATES --log-format simple --log-interval 100 \
-    --ddp-backend=no_c10d \
-    --arch gert \
-    --tensorboard-logdir $TB_DIR \
-    --bpe gpt2 --memory-efficient-fp16 \
-    --num-workers $NPROC_PER_NODE \
-    --save-interval-updates 300 \
-    --save-dir $SAVE_DIR &
+    if [ "$RANK" -eq "0" ]; then
+        export MASTER=$node
+        echo "Designating $node as master"
+    fi
     RANK=$((RANK+1))
 done
+srun ./local_training_wrapper.sh
 wait

--- a/find_my_rank.py
+++ b/find_my_rank.py
@@ -1,0 +1,17 @@
+#!/bin/env python
+import socket
+import sys
+
+# Take the first (and only) argument as a path to the rank file
+# and find my rank given hostname.
+
+host = socket.gethostname()
+path_to_rank_file = sys.argv[1]
+
+rank = None
+with open(path_to_rank_file, 'r') as f:
+    for line in f.readlines():
+        if line.startswith(host):
+            rank = line.split()[1]
+
+print(rank)

--- a/local_training_wrapper.sh
+++ b/local_training_wrapper.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This is its own script because we want `find_by_rank` to execute in local node context.
+
+RANK=`python /mnt/home/cchandler/Development/shaggy-dog/find_my_rank.py $SAVE_DIR/ranklist`
+
+echo "My rank is $RANK"
+python -m torch.distributed.launch \
+    --nproc_per_node=$NPROC_PER_NODE \
+    --nnodes=$SLURM_JOB_NUM_NODES \
+    --node_rank=$RANK \
+    --master_addr="$MASTER" \
+    --master_port="$MPORT" \
+    $(which fairseq-train) $DATA_DIR \
+    --task masked_lm --criterion masked_lm \
+    --sample-break-mode complete --tokens-per-sample $TOKENS_PER_SAMPLE \
+    --optimizer adam --adam-betas '(0.9,0.98)' --adam-eps 1e-6 --clip-norm 0.0 \
+    --lr-scheduler polynomial_decay --lr $PEAK_LR --warmup-updates $WARMUP_UPDATES --total-num-update $TOTAL_UPDATES \
+    --dropout 0.1 --attention-dropout 0.1 --weight-decay 0.01 \
+    --max-sentences $MAX_SENTENCES --update-freq $UPDATE_FREQ \
+    --max-update $TOTAL_UPDATES --log-format simple --log-interval 100 \
+    --arch gert \
+    --tensorboard-logdir $TB_DIR \
+    --bpe gpt2 --memory-efficient-fp16 \
+    --num-workers 1 \
+    --save-interval-updates 300 \
+    --skip-invalid-size-inputs-valid-test \
+    --distributed-no-spawn \
+    --distributed-port $MPORT \
+    --distributed-world-size $WORLDSIZE \
+    --save-dir $SAVE_DIR
+

--- a/node_to_rank_writer.py
+++ b/node_to_rank_writer.py
@@ -1,0 +1,17 @@
+#!/bin/env python
+import fileinput
+import sys
+
+# Take a single argument as a path to a file that we should write a list
+# of all nodes and their expected ranks.
+
+outfile = sys.argv[1]
+print(f"Writing to {outfile}")
+with open(outfile, 'w+') as f:
+    rank = 0
+    for line in sys.stdin:
+        nodes = line.strip().split()
+        for node in nodes:
+            f.write(f"{node} {rank}\n")
+            rank += 1
+


### PR DESCRIPTION
This probably needs a little more cleanup but it gets the jist across :-).

I've added a few comments in the main `distributed_train.sh`. The key differences are that all the fairseq variables are now getting exported so they will trickle into `local_training_wrapper.sh`. As far as I can tell slurm doesn't really have a mechanism to pass different arguments to srun on a per-node basis so we get around that by writing all the expected nodes + ranks to a file ahead of time. I'm using the save directory for that since it shouldn't interfere. I also decided on a port 4664 (nothing special about it) for the work since, at least in our environment, it greatly simplifies startup.

Also of note, this is currently using my custom build pytorch but it might not be needed. I'm going to verify after lunch it works on the standard install.